### PR TITLE
Remove ckpts directory, log path

### DIFF
--- a/toddlerbot/policies/mjx_policy.py
+++ b/toddlerbot/policies/mjx_policy.py
@@ -28,9 +28,10 @@ def load_wandb_policy(
     name: str, project="ToddlerBot", entity="toddlerbot"
 ) -> Dict[str, Any]:
     """Load a policy from WandB artifacts."""
-    root = os.path.join("ckpts", name)
+    root = os.path.join("", name)
     ckpt_path = os.path.join(root, "model_best.onnx")
     if not os.path.exists(ckpt_path):
+        print(f"File does not exist: {ckpt_path}, loading from wandb...")
         if wandb.run:
             run = wandb.run
         else:


### PR DESCRIPTION
When I trained, I got results in results/, not cpkts/results/, so I couldn't run my trained models.

Maybe remove the ckpts/ in root path, or maybe train to ckpts/ ?

Also, I provided path with file name in it:
```
--path results/toddlerbot_2xc_walk_rsl_20250930_224609/model_best.onnx
```
so I didn't know why it was failing and trying wandb for the model, so added a print to help users know.