### PR TITLE
Allow running the sim with no IMU library

### DIFF
--- a/toddlerbot/sim/real_world.py
+++ b/toddlerbot/sim/real_world.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 from scipy.spatial.transform import Rotation as R
 
 from toddlerbot.actuation import dynamixel_cpp
-from toddlerbot.sensing.IMU import ThreadedIMU
+try:
+    from toddlerbot.sensing.IMU import ThreadedIMU
+except:
+    print("IMU not found")
 from toddlerbot.sim import BaseSim, Obs
 from toddlerbot.sim.robot import Robot
 


### PR DESCRIPTION
If you run this on my mac, you get this error. This allows you to run the sim without needing to install the IMU library locally.

Maybe there's a better place to put this try catch or a better way to do it, but this works.

(toddlerbot) thomasjacobs@Thomass-Laptop toddlerbot % mjpython toddlerbot/policies/run_policy.py --policy walk --path results/toddlerbot_2xc_walk_rsl_20250930_224609/model_best.onnx --vis view
2025-10-01 15:34:48.953 mjpython[14768:11106417] WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application. Opt-in to secure coding explicitly by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState:.
Traceback (most recent call last):
  File "/Users/thomasjacobs/Documents/GitHub/toddlerbot/toddlerbot/policies/run_policy.py", line 24, in <module>
    from toddlerbot.sim.real_world import RealWorld
  File "/Users/thomasjacobs/Documents/GitHub/toddlerbot/toddlerbot/sim/real_world.py", line 15, in <module>
    from toddlerbot.sensing.IMU import ThreadedIMU
  File "/Users/thomasjacobs/Documents/GitHub/toddlerbot/toddlerbot/sensing/IMU.py", line 13, in <module>
    import board
  File "/opt/anaconda3/envs/toddlerbot/lib/python3.10/site-packages/board.py", line 487, in <module>
    raise NotImplementedError(
NotImplementedError:
        adafruit-platformdetect version 3.84.0 was unable to identify the board and/or
        microcontroller running the Darwin platform. Please be sure you
        have the latest packages by running:
        'pip3 install --upgrade adafruit-blinka adafruit-platformdetect'

        If you are running the latest package, your board may not yet be supported. Please
        open a New Issue on GitHub at https://github.com/adafruit/Adafruit_Blinka/issues and
        select New Board Request.
