### PR TITLE
Update README with MacOS command for policy run

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Refer to [this page](https://hshi74.github.io/toddlerbot/software/01_setup.html)
     ```
     python toddlerbot/policies/run_policy.py --policy replay --path motion/push_up_2xc.lz4 --vis view
     ```
+    (on MacOS)
+    ```
+    mjpython toddlerbot/policies/run_policy.py --policy replay --path motion/push_up_2xc.lz4 --vis view
+    ```
+    
 
     to see the push up motion in MuJoCo. You're very welcome to contribute your keyframe animation to our repository by
     submitting a pull request!


### PR DESCRIPTION
Add MacOS command for running the policy in README.

Otherwise, would get error:
`RuntimeError: launch_passive requires that the Python script be run under mjpython on macOS`