### PR TITLE
Add Discord invite link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ We truly appreciate your feedback and will do our best to address it!
 
 Join our [Discord](https://discord.gg/rwXqdvVtqh) to chat with the community!
 
-See [our website](https://toddlerbot.github.io/) for the WeChat community link.
-
 ## Contributing  
 
 We welcome contributions from the community! To contribute, just follow the standard practice:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ We truly appreciate your feedback and will do our best to address it!
 
 ## Community
 
-Join our [Discord](https://discord.gg/rwXqdvVtqh) to chat with the community!
+Join our <img src="https://cdn.simpleicons.org/discord/5865F2" height="14" alt=""> [Discord](https://discord.gg/rwXqdvVtqh) to chat with the community!
 
 ## Contributing  
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![ToddlerBot](docs/_static/banner.png)
 
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/rwXqdvVtqh)
+
 |  | Paper | Website | Tweet |
 |:--|:-----:|:-------:|:-----:|
 | **Locomotion Beyond Feet** (2026) | [arXiv](https://arxiv.org/abs/2601.03607) | [Site](https://locomotion-beyond-feet.github.io/) | [X](https://x.com/taeyang___11/status/2009359173302276391) |
@@ -124,7 +126,9 @@ We truly appreciate your feedback and will do our best to address it!
 
 ## Community
 
-See [our website](https://toddlerbot.github.io/) for links to join the Discord or WeChat community!
+Join our [Discord](https://discord.gg/rwXqdvVtqh) to chat with the community!
+
+See [our website](https://toddlerbot.github.io/) for the WeChat community link.
 
 ## Contributing  
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ![ToddlerBot](docs/_static/banner.png)
 
-[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/rwXqdvVtqh)
-
 |  | Paper | Website | Tweet |
 |:--|:-----:|:-------:|:-----:|
 | **Locomotion Beyond Feet** (2026) | [arXiv](https://arxiv.org/abs/2601.03607) | [Site](https://locomotion-beyond-feet.github.io/) | [X](https://x.com/taeyang___11/status/2009359173302276391) |


### PR DESCRIPTION
## Summary

Adds the ToddlerBot Discord invite to the **Community** section of the README, replacing the line that pointed at the project website.

```diff
-See [our website](https://toddlerbot.github.io/) for links to join the Discord or WeChat community!
+Join our <img src="https://cdn.simpleicons.org/discord/5865F2" height="14" alt=""> [Discord](https://discord.gg/rwXqdvVtqh) to chat with the community!
```

## Notes

- The inline Discord logo is served from `cdn.simpleicons.org` (no Discord emoji exists in Unicode, and `<img>` is used because markdown image syntax has no height control). If GitHub's image proxy doesn't render it, the fallback is committing the SVG under `docs/_static/` and referencing it locally.
- WeChat is no longer mentioned in the README. The project website is still linked from the table at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)